### PR TITLE
fix: httpx.ConnectTimeout in srpanel

### DIFF
--- a/march7th/nonebot_plugin_srpanel/model.py
+++ b/march7th/nonebot_plugin_srpanel/model.py
@@ -274,11 +274,11 @@ async def request(url: str) -> Optional[Dict]:
         headers={"User-Agent": "Mar-7th/March7th"},
         timeout=10,
     )
-    response = await driver.request(request)
     try:
+        response = await driver.request(request)
         data = json.loads(response.content or "{}")
         return data
-    except (json.JSONDecodeError, KeyError):
+    except:
         return None
 
 


### PR DESCRIPTION
一些地区（比如我所在地区）访问 https://ghproxy.com 访问不到，会导致超时，于是乎引出了如果 request 函数网络请求失败会导致整个程序崩溃的问题。