### PR TITLE
fix: image send failed when running in docker (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 ### Python Patch ###
 # Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration

--- a/march7th/nonebot_plugin_srres/config.py
+++ b/march7th/nonebot_plugin_srres/config.py
@@ -9,6 +9,13 @@ class Config(BaseModel, extra=Extra.ignore):
     sr_wiki_url: Optional[
         str
     ] = "https://raw.githubusercontent.com/Mar-7th/StarRailRes/master"
+    # file, base64
+    # 当QQ客户端与bot端不在同一台计算机时，可用 base64 协议
+    sr_wiki_send_protocol: Optional[str] = 'file'
 
 
 plugin_config = Config(**get_driver().config.dict())
+
+# 若非可选值则重置回默认
+if plugin_config.sr_wiki_send_protocol not in ['file', 'base64']:
+    plugin_config.sr_wiki_send_protocol = 'file'

--- a/march7th/nonebot_plugin_srres/config.py
+++ b/march7th/nonebot_plugin_srres/config.py
@@ -11,11 +11,11 @@ class Config(BaseModel, extra=Extra.ignore):
     ] = "https://raw.githubusercontent.com/Mar-7th/StarRailRes/master"
     # file, base64
     # 当QQ客户端与bot端不在同一台计算机时，可用 base64 协议
-    sr_wiki_send_protocol: Optional[str] = 'file'
+    sr_wiki_send_protocol: Optional[str] = "file"
 
 
 plugin_config = Config(**get_driver().config.dict())
 
 # 若非可选值则重置回默认
-if plugin_config.sr_wiki_send_protocol not in ['file', 'base64']:
-    plugin_config.sr_wiki_send_protocol = 'file'
+if plugin_config.sr_wiki_send_protocol not in ["file", "base64"]:
+    plugin_config.sr_wiki_send_protocol = "file"

--- a/march7th/nonebot_plugin_srres/data_source.py
+++ b/march7th/nonebot_plugin_srres/data_source.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional, TypedDict
 
 import httpx
-from nonebot.log import logger
 from PIL import Image
+from nonebot.log import logger
 from pydantic import parse_obj_as
 from nonebot_plugin_datastore import get_plugin_data
 
@@ -147,10 +147,10 @@ class StarRailRes:
         return status
 
     def _checked_res(self, path: Path) -> Optional[Path | BytesIO]:
-        if plugin_config.sr_wiki_send_protocol == 'base64':
+        if plugin_config.sr_wiki_send_protocol == "base64":
             buf = BytesIO()
             img = Image.open(path)
-            img.save(buf, 'PNG')
+            img.save(buf, "PNG")
             img.close()
             return buf
         else:


### PR DESCRIPTION
通过添加配置选项的方式，让三月七支持发送图片时不使用直接路径。

配置项：sr_wiki_send_protocol
可选值："base64"、"file"